### PR TITLE
Added script and supporting configs for launching local dev env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 **/build/
 !**/src/**/build/
 /bin
+backend/bin
 # Ignore Gradle GUI config
 gradle-app.setting
 

--- a/dev-start.sh
+++ b/dev-start.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+cleanup() {
+    echo "Stopping services..."
+    kill $BACKEND_PID $FRONTEND_PID 2>/dev/null
+    docker-compose -f docker-compose-local.yml down
+    exit
+}
+
+# Start nginx proxy
+echo "Starting nginx proxy..."
+docker-compose -f docker-compose-local.yml up -d
+
+# Start backend
+echo "Starting backend..."
+cd backend
+./gradlew bootRun &
+BACKEND_PID=$!
+cd ..
+
+# Start frontend
+echo "Starting frontend..."
+cd frontend
+npm run dev &
+FRONTEND_PID=$!
+cd ..
+
+echo "Development environment started!"
+echo "Frontend: http://localhost:3000"
+echo "Backend: http://localhost:8080"
+echo "App (via nginx): http://localhost:4444"
+echo ""
+echo "Press Ctrl+C to stop all services"
+
+# Wait for interrupt
+trap cleanup INT
+wait

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -1,0 +1,13 @@
+version: "3.9"
+
+services:
+  nginx:
+    image: nginx:stable
+    container_name: app-proxy-local
+    volumes:
+      - ./nginx/default.local.conf:/etc/nginx/conf.d/default.conf:ro
+    ports:
+      - "4444:80"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    restart: unless-stopped

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -4,4 +4,8 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    host: '0.0.0.0', // Allow external connections
+    port: 3000,
+  }
 })

--- a/nginx/default.local.conf
+++ b/nginx/default.local.conf
@@ -1,0 +1,27 @@
+server {
+    listen 80;
+    server_name _;
+
+    # ---- Proxy API to local Spring ----
+    location /api/ {
+        proxy_pass http://host.docker.internal:8080/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # ---- Proxy to local Vite dev server ----
+    location / {
+        proxy_pass http://host.docker.internal:3000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        
+        # WebSocket support for HMR
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+    }
+}


### PR DESCRIPTION
## Overview
When developing, short cycle times make it easier to iterate on changes. This PR makes it easy to spin up local instances of the application components, done in a way which minimizes the difference between local and prod. For instance, by still using nginx locally, we retain the behavior of the backend having the API at `/greeting` whereas the frontend views it as `/api/greeting`.

## Changes
### .gitignore
* After changing the directory structure, the ignore entry for `/bin` stopped doing what it was supposed to. Updated to `/backend/bin`

### dev-start.sh
* Script to start the environment for local development
* Backend runs via the `bootRun` gradle task
* Frontend runs via `npm run dev`
* Nginx runs in a docker container and is launched via `docker-compose-local.yml`

### docker-compose-local.yml
* Docker compose file for local docker resources

### vite.config.ts
* Didn't test without these changes, but may be related to crossing network interfaces 

### default.local.conf
* Nginx config to be used for local development

## Testing
* Ran the script, observed frontend loading at `http://localhost:4444`, observed successful API invocation to backend when clicking the get greeting button
* Ran `docker-compose up --build` and confirmed the fully containerized prod resources launched and worked as expected (same observations as previous bullet)